### PR TITLE
Add option to directly link to the overview page.

### DIFF
--- a/page-editor.js
+++ b/page-editor.js
@@ -52,6 +52,9 @@ function main(cookieMap) {
         if (cookieMap == null || cookieMap.get("hover")) {
             addToolTipHover(cookieMap);
         }
+        if (cookieMap == null || cookieMap.get("course-links")) {
+            modifyCourseLinks();
+        }
     }
 
     // search selection
@@ -165,4 +168,12 @@ function addCheckbox(id, name, checked) {
     document.getElementById("customreview").appendChild(checkbox);
     document.getElementById("customreview").appendChild(label);
     document.getElementById("customreview").appendChild(document.createElement('br'));
+}
+
+function modifyCourseLinks() {
+    document.querySelectorAll("td > b > a").forEach(link => {
+        if (link.href.includes("LEHRVERANSTALTUNGEN")) {
+            link.href = link.href.replace("LEHRVERANSTALTUNGEN", "ALLE")
+        }
+    })
 }

--- a/popup.html
+++ b/popup.html
@@ -109,6 +109,18 @@
         <input type="checkbox" id="old" class="toggle-checkbox">
         <label for="old" class="toggle-label"></label>
     </div>
+    Directly link to course Overview page:
+    <div class="tooltip">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
+            <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z" />
+            <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z" />
+        </svg>
+        <span class="tooltiptext">This modifies the link to the individual course pages such that it directly opens the overview.</span>
+    </div>
+    <div class="toggle-container">
+        <input type="checkbox" id="course-links" class="toggle-checkbox">
+        <label for="course-links" class="toggle-label"></label>
+    </div>
     Information on hover in search results:
     <div class="tooltip">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">

--- a/popup.js
+++ b/popup.js
@@ -5,7 +5,7 @@ if (navigator.userAgent.includes("Firefox")) {
     browser = chrome;
 }
 var extra = ["hovercourse", "hoverlearnmat", "hovergroups", "hoverrestrict", "hoveroffered"];
-var checks = ["all", "crlinks", "rating", "timetable", "autofill", "filter", "hover", "hovercatdata", "hoverperform", "enter", "old"];
+var checks = ["all", "crlinks", "rating", "timetable", "autofill", "filter", "hover", "hovercatdata", "hoverperform", "enter", "old", "course-links"];
 checks = checks.concat(extra);
 
 // Function to handle toggle change event


### PR DESCRIPTION
Hey, thanks for this cool extension that you maintain. It makes browsing the VVZ much more convenient.

There is only one thing that I miss: Whenever I open a course, it links to the tab "Lehrveranstaltungen", even though the tab "Übersicht" would be much more useful in my eyes. So I created this PR, which adds the option to link directly to the overview page.